### PR TITLE
Misc updates

### DIFF
--- a/src/main/java/com/vertispan/webdriver/gwt/gwtdriver/SeExporterGenerator.java
+++ b/src/main/java/com/vertispan/webdriver/gwt/gwtdriver/SeExporterGenerator.java
@@ -209,7 +209,7 @@ public class SeExporterGenerator extends Generator {
           } else if (type.isClass() != null
               && elementalNode != null
               && type.isClass().isAssignableTo(elementalNode)) {
-            sw.print("jsinterop.base.Js.uncheckedCast(args.get(%1$d))", i,
+            sw.print("jsinterop.base.Js.cast(args.get(%1$d))", i,
                 type.getQualifiedSourceName());
           } else if (type.isInterface() != null && oracle.getSingleJsoImplInterfaces()
               .contains(type.isInterface())) {

--- a/src/main/java/com/vertispan/webdriver/gwt/gwtdriver/by/ByNearestWidget.java
+++ b/src/main/java/com/vertispan/webdriver/gwt/gwtdriver/by/ByNearestWidget.java
@@ -46,7 +46,7 @@ import java.util.List;
  */
 public class ByNearestWidget extends By {
   private final WebDriver driver;
-  private final Class<?> widget;
+  private final String widgetClassName;
 
   /**
    * Finds the nearest containing widget of any type - anything that extends Widget will be found.
@@ -67,8 +67,21 @@ public class ByNearestWidget extends By {
    * @param type the type of widget to find
    */
   public ByNearestWidget(WebDriver driver, Class<? extends Widget> type) {
-    this.widget = type;
+    this(driver, type.getName());
+  }
+
+  /**
+   * Finds the nearest containing widget of the given type. This will find any subtype of that
+   * widget, allowing you to pass in {@link ValueBoxBase} and find any {@link TextBox}, {@link
+   * TextArea}, {@link IntegerBox}, etc, as these are all subclasses of {@code ValueBoxBase}. Note
+   * that interfaces cannot be used, only base classes, and those classes *must* extend Widget.
+   *
+   * @param driver the driver to use to communicate with the browser
+   * @param widgetClassName the type of widget to find
+   */
+  public ByNearestWidget(WebDriver driver, String widgetClassName) {
     this.driver = driver;
+    this.widgetClassName = widgetClassName;
   }
 
   @Override
@@ -84,7 +97,7 @@ public class ByNearestWidget extends By {
   public WebElement findElement(SearchContext context) {
     WebElement potentialElement = tryFindElement(context);
     if (potentialElement == null) {
-      throw new NoSuchElementException("Cannot find a " + widget.getName() + " in " + context);
+      throw new NoSuchElementException("Cannot find a " + widgetClassName + " in " + context);
     }
     return potentialElement;
   }
@@ -99,13 +112,14 @@ public class ByNearestWidget extends By {
   private WebElement tryFindElement(SearchContext context) {
     WebElement elt = context.findElement(By.xpath("."));
     ExportedMethods m = ClientMethodsFactory.create(ExportedMethods.class, driver);
-    WebElement potentialElement = m.getContainingWidgetEltOfType(elt, widget.getName());
+    WebElement potentialElement = m.getContainingWidgetEltOfType(elt, widgetClassName);
     return potentialElement;
   }
 
   @Override
   public String toString() {
-    return "ByNearestWidget" + (widget == Widget.class ? "" : " " + widget.getName());
+    return "ByNearestWidget"
+        + (Widget.class.getName().equals(widgetClassName) ? "" : " " + widgetClassName);
   }
 
 }

--- a/src/main/java/com/vertispan/webdriver/gwt/gwtdriver/by/ByWidget.java
+++ b/src/main/java/com/vertispan/webdriver/gwt/gwtdriver/by/ByWidget.java
@@ -45,8 +45,12 @@ public class ByWidget extends By {
   }
 
   public ByWidget(WebDriver driver, Class<? extends Widget> widgetType) {
+    this(driver, widgetType.getName());
+  }
+
+  public ByWidget(WebDriver driver, String className) {
     this.driver = driver;
-    this.type = widgetType.getName();
+    this.type = className;
   }
 
   @Override

--- a/src/main/java/com/vertispan/webdriver/gwt/gwtdriver/models/GwtWidgetFinder.java
+++ b/src/main/java/com/vertispan/webdriver/gwt/gwtdriver/models/GwtWidgetFinder.java
@@ -65,14 +65,9 @@ public class GwtWidgetFinder<W extends GwtWidget<?>> {
   }
 
   public W waitFor(Duration duration) {
-    return new FluentWait<WebDriver>(driver)
+    return new FluentWait<>(driver)
         .withTimeout(duration)
         .ignoring(NotFoundException.class)
-        .until(new Function<WebDriver, W>() {
-          @Override
-          public W apply(WebDriver webDriver) {
-            return done();
-          }
-        });
+        .until((Function<WebDriver, W>) webDriver -> done());
   }
 }


### PR DESCRIPTION
- overloaded By constructors to take strings as well; in case the test module does not depend on the module containing the widgets
- Added support to use Elemental2 Nodes in exported methods interface rather than the JSO "Element", we can use elemental2.dom.HTMLElement
- Added support for returning @JsType objects; these will result in a Map<String, Object> on the selenium side