### PR TITLE
gwt-driver-7 Add faster child/descendant Widget locator

### DIFF
--- a/LICENSE_VERTISPAN
+++ b/LICENSE_VERTISPAN
@@ -1,0 +1,13 @@
+Copyright 2022 Vertispan LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/pom.xml
+++ b/pom.xml
@@ -212,20 +212,55 @@
       <plugin>
         <groupId>com.mycila</groupId>
         <artifactId>license-maven-plugin</artifactId>
-        <version>3.0</version>
+        <version>4.2.rc2</version>
         <configuration>
           <mapping>
             <gss>JAVADOC_STYLE</gss>
             <java>SLASHSTAR_STYLE</java>
           </mapping>
-          <includes>
-            <include>**/*.java</include>
-            <include>**/*.gss</include>
-            <include>**/*.gwt.xml</include>
-            <include>**/*.ui.xml</include>
-            <include>**/*.html</include>
-          </includes>
-          <header>LICENSE</header>
+
+          <licenseSets>
+            <licenseSet>
+              <header>LICENSE_VERTISPAN</header>
+              <includes>
+                <include>**/*.java</include>
+                <include>**/*.gss</include>
+                <include>**/*.gwt.xml</include>
+                <include>**/*.ui.xml</include>
+                <include>**/*.html</include>
+              </includes>
+            </licenseSet>
+            <licenseSet>
+              <header>LICENSE</header>
+              <!-- grandfathered -->
+              <includes>
+                <include>**/Button.java</include>
+                <include>**/ByNearestWidget.java</include>
+                <include>**/ByWidget.java</include>
+                <include>**/CheatingByChained.java</include>
+                <include>**/Child.java</include>
+                <include>**/ClientMethods.java</include>
+                <include>**/ClientMethodsFactory.java</include>
+                <include>**/Dialog.java</include>
+                <include>**/ExportedMethods.java</include>
+                <include>**/FasterByChained.java</include>
+                <include>**/GwtDriver.gwt.xml</include>
+                <include>**/GwtLabel.java</include>
+                <include>**/GwtRootPanel.java</include>
+                <include>**/GwtWidget.java</include>
+                <include>**/GwtWidgetFinder.java</include>
+                <include>**/Input.java</include>
+                <include>**/ModuleUtilities.java</include>
+                <include>**/SeExporterGenerator.java</include>
+                <include>**/SeleniumExporter.java</include>
+                <include>**/SimpleWidgetTest.java</include>
+                <include>**/SimpleWidgets.gwt.xml</include>
+                <include>**/SimpleWidgetsEP.java</include>
+                <include>**/WidgetContainer.java</include>
+                <include>**/index.html</include>
+              </includes>
+            </licenseSet>
+          </licenseSets>
         </configuration>
         <executions>
           <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -222,6 +222,7 @@
             <include>**/*.java</include>
             <include>**/*.gss</include>
             <include>**/*.gwt.xml</include>
+            <include>**/*.ui.xml</include>
             <include>**/*.html</include>
           </includes>
           <header>LICENSE</header>

--- a/src/main/java/com/vertispan/webdriver/gwt/gwtdriver/by/ByDescendantWidget.java
+++ b/src/main/java/com/vertispan/webdriver/gwt/gwtdriver/by/ByDescendantWidget.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2013 Colin Alworth
+ * Copyright 2012-2013 Sencha Labs
+ * Copyright 2022 Vertispan LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.vertispan.webdriver.gwt.gwtdriver.by;
+
+import com.google.gwt.user.client.ui.Widget;
+
+import com.vertispan.webdriver.gwt.gwtdriver.invoke.ClientMethodsFactory;
+import com.vertispan.webdriver.gwt.gwtdriver.invoke.ExportedMethods;
+
+import org.openqa.selenium.NoSuchElementException;
+import org.openqa.selenium.SearchContext;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.internal.Require;
+
+import java.util.List;
+
+
+/**
+ * GWT specific {@code By} implementation that finds descendant widgets.
+ * <p>
+ * As this {@code By} calls the GWT module itself, it will only locate descendants if the {@link
+ * com.google.gwt.user.client.ui.HasWidgets} hierarchy is setup correctly.  For example, if a Widget
+ * takes the Element from another Widget, but does not implement HasWidgets, this {@code By} will
+ * not locate the other Widget.
+ */
+public class ByDescendantWidget extends GwtBy {
+  private final String type;
+
+  /**
+   * Finds the descendant Widgets of any type - anything that extends Widget will be found.
+   */
+  public ByDescendantWidget() {
+    this((WebDriver) null);
+  }
+
+  /**
+   * Finds the descendant Widgets of any type - anything that extends Widget will be found.
+   *
+   * @param driver The driver to use to communicate with the browser.
+   */
+  public ByDescendantWidget(WebDriver driver) {
+    this(driver, Widget.class);
+  }
+
+  /**
+   * Finds the descendant Widgets of the given type.
+   * <p>
+   * This will find any subtype of that widget, allowing you to pass in {@link
+   * com.google.gwt.user.client.ui.ValueBoxBase} and find any {@link com.google.gwt.user.client.ui.TextBox},
+   * {@link com.google.gwt.user.client.ui.TextArea}, {@link com.google.gwt.user.client.ui.IntegerBox},
+   * etc, as these are all subclasses of {@code ValueBoxBase}.  Note that interfaces cannot be used,
+   * only base classes, and those classes *must* extend Widget.
+   *
+   * @param widgetType The type of widget to find
+   */
+  public ByDescendantWidget(Class<? extends Widget> widgetType) {
+    this(widgetType.getName());
+  }
+
+  /**
+   * Finds the descendant Widgets of the given type.
+   * <p>
+   * This will find any subtype of that widget, allowing you to pass in {@link
+   * com.google.gwt.user.client.ui.ValueBoxBase} and find any {@link com.google.gwt.user.client.ui.TextBox},
+   * {@link com.google.gwt.user.client.ui.TextArea}, {@link com.google.gwt.user.client.ui.IntegerBox},
+   * etc, as these are all subclasses of {@code ValueBoxBase}.  Note that interfaces cannot be used,
+   * only base classes, and those classes *must* extend Widget.
+   *
+   * @param driver The driver to use to communicate with the browser.
+   * @param widgetType The type of widget to find
+   */
+  public ByDescendantWidget(WebDriver driver, Class<? extends Widget> widgetType) {
+    this(driver, widgetType.getName());
+  }
+
+
+  /**
+   * Finds the descendant Widgets of the given type.
+   * <p>
+   * This will find any subtype of that widget, allowing you to pass in {@link
+   * com.google.gwt.user.client.ui.ValueBoxBase} and find any {@link com.google.gwt.user.client.ui.TextBox},
+   * {@link com.google.gwt.user.client.ui.TextArea}, {@link com.google.gwt.user.client.ui.IntegerBox},
+   * etc, as these are all subclasses of {@code ValueBoxBase}.  Note that interfaces cannot be used,
+   * only base classes, and those classes *must* extend Widget.
+   *
+   * @param widgetClassName The type of widget to find
+   */
+  public ByDescendantWidget(String widgetClassName) {
+    this(null, widgetClassName);
+  }
+
+  /**
+   * Finds the descendant Widgets of the given type.
+   * <p>
+   * This will find any subtype of that widget, allowing you to pass in {@link
+   * com.google.gwt.user.client.ui.ValueBoxBase} and find any {@link com.google.gwt.user.client.ui.TextBox},
+   * {@link com.google.gwt.user.client.ui.TextArea}, {@link com.google.gwt.user.client.ui.IntegerBox},
+   * etc, as these are all subclasses of {@code ValueBoxBase}.  Note that interfaces cannot be used,
+   * only base classes, and those classes *must* extend Widget.
+   *
+   * @param driver The driver to use to communicate with the browser.
+   * @param widgetClassName The type of widget to find
+   */
+  public ByDescendantWidget(WebDriver driver, String widgetClassName) {
+    super(driver);
+    this.type = widgetClassName;
+  }
+
+
+  @Override
+  public List<WebElement> findElements(SearchContext context) {
+    Require.nonNull("Search Context", context);
+    final WebElement contextElem = toWebElement(context);
+
+    ExportedMethods m = ClientMethodsFactory.create(ExportedMethods.class, getDriver(context));
+    // could return empty list
+    return m.findDescendantWidgetElementsOfType(contextElem, type);
+  }
+
+  @Override
+  public WebElement findElement(SearchContext context) {
+    Require.nonNull("Search Context", context);
+    final WebElement contextElem = toWebElement(context);
+
+    ExportedMethods m = ClientMethodsFactory.create(ExportedMethods.class, getDriver(context));
+    WebElement first = m.findFirstDescendantWidgetElementsOfType(contextElem, type);
+    if (first == null) {
+      throw new NoSuchElementException("Cannot find widget of type " + type);
+    }
+    return first;
+  }
+
+  @Override
+  public String toString() {
+    return "ByDescendantWidget{" +
+        "type='" + type + '\'' +
+        '}';
+  }
+}

--- a/src/main/java/com/vertispan/webdriver/gwt/gwtdriver/by/ByDescendantWidget.java
+++ b/src/main/java/com/vertispan/webdriver/gwt/gwtdriver/by/ByDescendantWidget.java
@@ -1,6 +1,4 @@
 /*
- * Copyright 2013 Colin Alworth
- * Copyright 2012-2013 Sencha Labs
  * Copyright 2022 Vertispan LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/vertispan/webdriver/gwt/gwtdriver/by/ByWidgetChildren.java
+++ b/src/main/java/com/vertispan/webdriver/gwt/gwtdriver/by/ByWidgetChildren.java
@@ -1,6 +1,4 @@
 /*
- * Copyright 2013 Colin Alworth
- * Copyright 2012-2013 Sencha Labs
  * Copyright 2022 Vertispan LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/vertispan/webdriver/gwt/gwtdriver/by/CheatingByChained.java
+++ b/src/main/java/com/vertispan/webdriver/gwt/gwtdriver/by/CheatingByChained.java
@@ -33,7 +33,7 @@ import java.util.List;
  * When running {@link SearchContext#findElements} to search for multiple items, uses ByChained
  * normal.
  */
-public class CheatingByChained extends By {
+public class CheatingByChained extends GwtBy {
   private By[] bys;
 
   public CheatingByChained(By... bys) {

--- a/src/main/java/com/vertispan/webdriver/gwt/gwtdriver/by/FasterByChained.java
+++ b/src/main/java/com/vertispan/webdriver/gwt/gwtdriver/by/FasterByChained.java
@@ -35,7 +35,7 @@ import java.util.List;
  * Using this class should be functionally eqivelent to using ByChained, except faster in some
  * cases.
  */
-public class FasterByChained extends By {
+public class FasterByChained extends GwtBy {
   private By[] bys;
 
   public FasterByChained(By... bys) {

--- a/src/main/java/com/vertispan/webdriver/gwt/gwtdriver/by/GwtBy.java
+++ b/src/main/java/com/vertispan/webdriver/gwt/gwtdriver/by/GwtBy.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2013 Colin Alworth
+ * Copyright 2012-2013 Sencha Labs
+ * Copyright 2022 Vertispan LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.vertispan.webdriver.gwt.gwtdriver.by;
+
+import com.google.gwt.user.client.ui.Widget;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.SearchContext;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.WrapsDriver;
+
+/**
+ *
+ */
+public abstract class GwtBy extends By {
+
+  public static CheatingByChained cheatingChained(By... bys) {
+    return new CheatingByChained(bys);
+  }
+
+  public static FasterByChained fasterChained(By... bys) {
+    return new FasterByChained(bys);
+  }
+
+  // is widget
+
+  public static ByWidget isWidget() {
+    return new ByWidget();
+  }
+
+  public static ByWidget isWidget(Class<? extends Widget> widgetType) {
+    return new ByWidget(widgetType);
+  }
+
+  public static ByWidget isWidget(String widgetClassName) {
+    return new ByWidget(widgetClassName);
+  }
+
+  // nearest widget
+
+  public static ByNearestWidget nearestWidget() {
+    return new ByNearestWidget();
+  }
+
+  public static ByNearestWidget nearestWidget(Class<? extends Widget> widgetType) {
+    return new ByNearestWidget(widgetType);
+  }
+
+  public static ByNearestWidget nearestWidget(String widgetClassName) {
+    return new ByNearestWidget(widgetClassName);
+  }
+
+  // descendant widgets
+  public static ByDescendantWidget descendantWidget() {
+    return new ByDescendantWidget();
+  }
+
+  public static ByDescendantWidget descendantWidget(Class<? extends Widget> widgetType) {
+    return new ByDescendantWidget(widgetType);
+  }
+
+  public static ByDescendantWidget descendantWidget(String widgetClassName) {
+    return new ByDescendantWidget(widgetClassName);
+  }
+
+
+  private final WebDriver driver;
+
+  protected GwtBy() {
+    this(null);
+  }
+
+  protected GwtBy(WebDriver driver) {
+    this.driver = driver;
+  }
+
+
+  protected WebElement toWebElement(SearchContext context) {
+    final WebElement contextElem;
+    if (context instanceof WebElement) {
+      contextElem = (WebElement) context;
+    } else {
+      // most likely the driver
+      contextElem = context.findElement(By.xpath("//body"));
+    }
+    return contextElem;
+  }
+
+  protected WebDriver getDriver(SearchContext context) {
+    if (this.driver != null) {
+      return this.driver;
+    }
+
+    if (context instanceof WebDriver) {
+      return (WebDriver) context;
+    }
+
+    if (context instanceof WrapsDriver) {
+      return ((WrapsDriver) context).getWrappedDriver();
+    }
+
+    throw new IllegalArgumentException("Unable to get WebDriver from provided context.  "
+        + "Maybe use the constructor that takes a driver.");
+  }
+}

--- a/src/main/java/com/vertispan/webdriver/gwt/gwtdriver/by/GwtBy.java
+++ b/src/main/java/com/vertispan/webdriver/gwt/gwtdriver/by/GwtBy.java
@@ -1,6 +1,4 @@
 /*
- * Copyright 2013 Colin Alworth
- * Copyright 2012-2013 Sencha Labs
  * Copyright 2022 Vertispan LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/com/vertispan/webdriver/gwt/gwtdriver/by/GwtBy.java
+++ b/src/main/java/com/vertispan/webdriver/gwt/gwtdriver/by/GwtBy.java
@@ -30,53 +30,131 @@ import org.openqa.selenium.WrapsDriver;
  */
 public abstract class GwtBy extends By {
 
+  /**
+   * When looking for only one item, cheats by only looking for one item at each level.
+   * <p>
+   * Useful only if you want the first result of each {@link By} operation, otherwise use {@link
+   * #fasterChained(By...)} or {@link org.openqa.selenium.support.pagefactory.ByChained}.
+   */
   public static CheatingByChained cheatingChained(By... bys) {
     return new CheatingByChained(bys);
   }
 
+  /**
+   * When looking for only one item, speeds up the last {@link By} in the chain by only running it
+   * until it finds something.
+   * <p>
+   * When using   {@link SearchContext#findElements(By)}, uses {@link
+   * org.openqa.selenium.support.pagefactory.ByChained} to find all possible elements as normal.
+   * <p>
+   * Using this should be functionally equivalent to using {@link org.openqa.selenium.support.pagefactory.ByChained},
+   * except faster in some cases.
+   */
   public static FasterByChained fasterChained(By... bys) {
     return new FasterByChained(bys);
   }
 
+  // ----------
   // is widget
+  // ----------
 
+  /**
+   * Checks if context is a widget of any type - anything that extends Widget.
+   */
   public static ByWidget isWidget() {
     return new ByWidget();
   }
 
+  /**
+   * Checks if context is a widget of the specified widgetType.
+   */
   public static ByWidget isWidget(Class<? extends Widget> widgetType) {
     return new ByWidget(widgetType);
   }
 
+  /**
+   * Checks if context is a widget of the specified widgetType.
+   */
   public static ByWidget isWidget(String widgetClassName) {
     return new ByWidget(widgetClassName);
   }
 
+  // ---------------
   // nearest widget
+  // ---------------
 
+  /**
+   * Looks at the current search context and above for the nearest Widget object.
+   */
   public static ByNearestWidget nearestWidget() {
     return new ByNearestWidget();
   }
 
+  /**
+   * Looks at the current search context and above for the nearest Widget object of provided
+   * widgetType.
+   */
   public static ByNearestWidget nearestWidget(Class<? extends Widget> widgetType) {
     return new ByNearestWidget(widgetType);
   }
 
+  /**
+   * Looks at the current search context and above for the nearest Widget object of provided
+   * widgetType.
+   */
   public static ByNearestWidget nearestWidget(String widgetClassName) {
     return new ByNearestWidget(widgetClassName);
   }
 
+  // ------------------
   // descendant widgets
+  // ------------------
+
+
+  /**
+   * Finds the descendant Widgets of any type - anything that extends Widget will be found.
+   */
   public static ByDescendantWidget descendantWidget() {
     return new ByDescendantWidget();
   }
 
+  /**
+   * Finds the descendant Widgets of the given type.
+   */
   public static ByDescendantWidget descendantWidget(Class<? extends Widget> widgetType) {
     return new ByDescendantWidget(widgetType);
   }
 
+  /**
+   * Finds the descendant Widgets of the given type.
+   */
   public static ByDescendantWidget descendantWidget(String widgetClassName) {
     return new ByDescendantWidget(widgetClassName);
+  }
+
+  // ------------------
+  // get children
+  // ------------------
+
+  /**
+   * Gets the children Widgets of any type - any child that extends Widget will be found.
+   */
+  public static ByWidgetChildren childrenWidgets() {
+    return new ByWidgetChildren();
+  }
+
+  /**
+   * Gets the children Widgets of the given type.
+   */
+  public static ByWidgetChildren childrenWidgets(Class<? extends Widget> widgetType) {
+    return new ByWidgetChildren(widgetType);
+  }
+
+  /**
+   * Gets the children Widgets of the given type.
+   */
+  public static ByWidgetChildren childrenWidgets(String widgetClassName) {
+    return new ByWidgetChildren(widgetClassName);
   }
 
 

--- a/src/main/java/com/vertispan/webdriver/gwt/gwtdriver/client/SeleniumExporter.java
+++ b/src/main/java/com/vertispan/webdriver/gwt/gwtdriver/client/SeleniumExporter.java
@@ -94,6 +94,22 @@ public abstract class SeleniumExporter implements EntryPoint {
       return w == null ? null : w.getElement();
     }
 
+    @Method("getChildren")
+    public JsArray<Element> getChildren(Element elt) {
+      Widget w = findContainingWidget(elt);
+      JsArray<Element> result = JsArray.createArray().cast();
+      if (!(w instanceof HasWidgets)) {
+        // null or not subtype of HasWidgets; so no children
+        return result;
+      }
+
+      for (Widget child : (HasWidgets) w) {
+        result.push(child.getElement());
+      }
+
+      return result;
+    }
+
     @Method("findDescendantWidgetElementsOfType")
     public JsArray<Element> findDescendantWidgetElementsOfType(Element elt, String type) {
       JsArray<Element> result = JsArray.createArray().cast();
@@ -113,8 +129,8 @@ public abstract class SeleniumExporter implements EntryPoint {
             nodesToVisit.add(child);
           }
         }
-        // only push if it's of the right type
-        if (isOfType(type, curr)) {
+        // only push if it's of the right type ; skip rootWidget
+        if (curr != rootWidget && isOfType(type, curr)) {
           result.push(curr.getElement());
         }
       }

--- a/src/main/java/com/vertispan/webdriver/gwt/gwtdriver/invoke/ExportedMethods.java
+++ b/src/main/java/com/vertispan/webdriver/gwt/gwtdriver/invoke/ExportedMethods.java
@@ -37,6 +37,13 @@ public interface ExportedMethods extends ClientMethods {
 //	String instanceOf(String type, Object instance);
 
   /**
+   * Returns all children of the Widget associated with context.
+   *
+   * If the widget is null or does not implement HasWidgets, an empty list will be returned.
+   */
+  List<WebElement> getChildren(WebElement context);
+
+  /**
    * Finds all descendant Widget elements below the context element matching className type.
    * <p>
    * This method will first find the nearest Widget from the context (going up the parent chain

--- a/src/main/java/com/vertispan/webdriver/gwt/gwtdriver/invoke/ExportedMethods.java
+++ b/src/main/java/com/vertispan/webdriver/gwt/gwtdriver/invoke/ExportedMethods.java
@@ -19,6 +19,8 @@ package com.vertispan.webdriver.gwt.gwtdriver.invoke;
 
 import org.openqa.selenium.WebElement;
 
+import java.util.List;
+
 public interface ExportedMethods extends ClientMethods {
   boolean isWidget(WebElement elt);
 
@@ -33,4 +35,38 @@ public interface ExportedMethods extends ClientMethods {
 //	String getClass(Object obj);
 
 //	String instanceOf(String type, Object instance);
+
+  /**
+   * Finds all descendant Widget elements below the context element matching className type.
+   * <p>
+   * This method will first find the nearest Widget from the context (going up the parent chain
+   * until it finds a Widget). From there, it will recursively traverse (breadth-first traversal) of
+   * all HasWidget types.
+   * <p>
+   * Will return empty list if context is null or unable to find a Widget from context element.
+   * <p>
+   * If nearest Widget to context element is not instanceof {@link com.google.gwt.user.client.ui.HasWidgets},
+   * this will return a single item; the Widget element.
+   */
+  List<WebElement> findDescendantWidgetElementsOfType(WebElement context, String className);
+
+  /**
+   * Finds all descendant Widget elements below the context element.
+   * <p>
+   * This method will first find the nearest Widget from the context (going up the parent chain
+   * until it finds a Widget). From there, it will recursively traverse (breadth-first traversal) of
+   * all HasWidget types.
+   * <p>
+   * Will return empty list if context is null or unable to find a Widget from context element.
+   * <p>
+   * If nearest Widget to context element is not instanceof {@link com.google.gwt.user.client.ui.HasWidgets},
+   * this will return a single item; the Widget element.
+   */
+  List<WebElement> findDescendantWidgetElements(WebElement context);
+
+  /**
+   * Finds the first descendant Widget element below the context element matching className type;
+   * breadth-first traversal.
+   */
+  WebElement findFirstDescendantWidgetElementsOfType(WebElement context, String className);
 }

--- a/src/test/java/com/vertispan/webdriver/gwt/gwtdriver/models/SimpleWidgetTest.java
+++ b/src/test/java/com/vertispan/webdriver/gwt/gwtdriver/models/SimpleWidgetTest.java
@@ -19,8 +19,8 @@ package com.vertispan.webdriver.gwt.gwtdriver.models;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import com.google.gwt.user.client.ui.FlowPanel;
 import com.google.gwt.user.client.ui.Label;
-import com.google.gwt.user.client.ui.Panel;
 import com.google.gwt.user.client.ui.RootPanel;
 import com.google.gwt.user.client.ui.TextBox;
 
@@ -50,6 +50,10 @@ import io.github.bonigarcia.wdm.WebDriverManager;
  * Simple initial tests to make sure the basics pass a smoke test, so lots of manual setup
  */
 public class SimpleWidgetTest {
+
+  // a bit dumb as this will have to be updated every time the test UI changes
+  private static final int TOTAL_WIDGET_COUNT = 13;
+
   public static class SmokeTestWidget {
     @Child(type = RootPanel.class)
     private GwtWidget widget;
@@ -103,31 +107,37 @@ public class SimpleWidgetTest {
   public void testWithDriver() throws Exception {
     driver.get(url);
 
-    WidgetContainer widget = new GwtRootPanel(driver);
-    assert widget.as(GwtRootPanel.class) != null;
+    WidgetContainer rootPanel = new GwtRootPanel(driver);
+    assert rootPanel.as(GwtRootPanel.class) != null;
 
-    List<GwtWidget<?>> children = widget.findWidgets(By.xpath(".//*"));
+    List<GwtWidget<?>> children = rootPanel.findWidgets(By.xpath(".//*"));
     //RootPanel
     //*Label
-    //*FlowPanel
-    //**TextBox
-    //**Button
-    assert children.size() == 5 : children.size();
+    //*UIBINDER Internals
+
+    // growing tests will be difficult to narrow down an exact count without having to continually
+    // update this value.
+    assertEquals(TOTAL_WIDGET_COUNT, children.size());
 
     //find Label by iterating through sub-widgets and as'ing
     GwtLabel label = children.get(0).as(GwtLabel.class);
-    assert label != null;
-    assert label.getText().equals("testing") : label.getText();
+    assertNotNull(label);
+    assertEquals("testing", label.getText());
 
     //find label by finder
-    GwtLabel label2 = widget.find(GwtLabel.class).withText("testing").done();
-    assert label2 != null;
-    assert label.getElement().equals(label2.getElement());
-    assert label.getText().equals("testing");
+    GwtLabel label2 = rootPanel.find(GwtLabel.class).withText("testing").done();
+    assertNotNull(label2);
+    assertEquals(label.getElement(), label2.getElement());
+    assertEquals("testing", label2.getText());
+
+    // find panel1 that contains form, button for dialog
+    WidgetContainer panel1 = rootPanel.findWidget(By.cssSelector(".panel1"))
+        .as(WidgetContainer.class);
+    List<GwtWidget<?>> panel1Children = panel1.findWidgets(By.xpath(".//*"));
 
     //find, as TextBox as input, verify text and enter new
-    Input textBox = children.get(2).as(Input.class);
-    assert "asdf".equals(textBox.getValue());
+    Input textBox = panel1Children.get(0).as(Input.class);
+    assertEquals("asdf", textBox.getValue());
     textBox.sendKeys("fdsa");
 
     //find, click button
@@ -135,14 +145,15 @@ public class SimpleWidgetTest {
 
     //find dialog by heading
     Dialog headingDialog = new DialogFinder().withHeading("Heading").withDriver(driver).done();
-    assert headingDialog != null;
-    assert headingDialog.getHeadingText().equals("Heading Text For Dialog");
+    assertNotNull(headingDialog);
+    assertEquals("Heading Text For Dialog", headingDialog.getHeadingText());
+
     //find dialog by top
     Dialog topDialog = new DialogFinder().atTop().withDriver(driver).done();
-    assert topDialog != null;
-    assert topDialog.getHeadingText().equals("Heading Text For Dialog");
+    assertNotNull(topDialog);
+    assertEquals("Heading Text For Dialog", topDialog.getHeadingText());
 
-    assert headingDialog.getElement().equals(topDialog.getElement());
+    assertEquals(topDialog.getElement(), headingDialog.getElement());
 
     Point initialHeaderLoc = topDialog.getElement().getLocation();
 
@@ -151,11 +162,8 @@ public class SimpleWidgetTest {
     actions.build().perform();
     Point movedHeaderLoc = topDialog.getElement().getLocation();
 
-    assert !movedHeaderLoc.equals(initialHeaderLoc);
-    //this line is a little screwy in htmlunit
-//			assert movedHeaderLoc.equals(children.get(3).getElement().getLocation());
-
-    assert topDialog.getElement().getText().contains("fdsa");
+    assertNotEquals(initialHeaderLoc, movedHeaderLoc);
+    assertTrue(topDialog.getElement().getText().contains("fdsa"));
   }
 
 
@@ -164,32 +172,45 @@ public class SimpleWidgetTest {
     driver.get(url);
 
     WidgetContainer rootPanel = new GwtRootPanel(driver);
-    assert rootPanel.as(GwtRootPanel.class) != null;
+    assertNotNull(rootPanel.as(GwtRootPanel.class));
 
     ExportedMethods exportedMethods = ClientMethodsFactory.create(ExportedMethods.class, driver);
 
+    // let's get the panel1 and only look under it
+    WidgetContainer panel1 = rootPanel.findWidget(By.cssSelector(".panel1"))
+        .as(WidgetContainer.class);
+
     // find all widgets under a context
     List<WebElement> allWidgetElements = exportedMethods
-        .findDescendantWidgetElements(rootPanel.getElement());
+        .findDescendantWidgetElements(panel1.getElement());
 
-    // should be 6 (including root panel)
-    assertEquals(6, allWidgetElements.size());
-    exportedMethods.instanceofwidget(allWidgetElements.get(1), Label.class.getName());
-    exportedMethods.instanceofwidget(allWidgetElements.get(2), Panel.class.getName());
-    exportedMethods.instanceofwidget(allWidgetElements.get(3), TextBox.class.getName());
-    exportedMethods.instanceofwidget(allWidgetElements.get(4),
+    // should be TOTAL_WIDGET_COUNT (excludes the parent panel)
+    assertEquals(3, allWidgetElements.size());
+    exportedMethods.instanceofwidget(allWidgetElements.get(0), TextBox.class.getName());
+    exportedMethods.instanceofwidget(allWidgetElements.get(1),
         com.google.gwt.user.client.ui.Button.class.getName());
-    exportedMethods.instanceofwidget(allWidgetElements.get(5), Label.class.getName());
+    exportedMethods.instanceofwidget(allWidgetElements.get(2), Label.class.getName());
 
     // find descendant of type
     List<WebElement> buttons = exportedMethods.findDescendantWidgetElementsOfType(
-        rootPanel.getElement(),
+        panel1.getElement(),
         com.google.gwt.user.client.ui.Button.class.getName());
     assertEquals(1, buttons.size());
 
-    // find first widget type
+    // find first widget type; using root panel as the context as we know the first
+    // widget is the label we're expecting
     WebElement firstLabel = exportedMethods.findFirstDescendantWidgetElementsOfType(
         rootPanel.getElement(), Label.class.getName());
     assertEquals("testing", new GwtLabel(driver, firstLabel).getText());
+
+
+    // let's validate direct children fetch; only looking in panel2
+    WidgetContainer panel2 = rootPanel.findWidget(By.cssSelector(".panel2"))
+        .as(WidgetContainer.class);
+    List<WebElement> panel2Children = exportedMethods.getChildren(panel2.getElement());
+    assertEquals(3, panel2Children.size());
+    exportedMethods.instanceofwidget(panel2Children.get(0), Label.class.getName());
+    exportedMethods.instanceofwidget(panel2Children.get(1), Button.class.getName());
+    exportedMethods.instanceofwidget(panel2Children.get(2), FlowPanel.class.getName());
   }
 }

--- a/src/test/java/com/vertispan/webdriver/gwt/gwtdriver/models/SimpleWidgetTest.java
+++ b/src/test/java/com/vertispan/webdriver/gwt/gwtdriver/models/SimpleWidgetTest.java
@@ -24,6 +24,7 @@ import com.google.gwt.user.client.ui.Label;
 import com.google.gwt.user.client.ui.RootPanel;
 import com.google.gwt.user.client.ui.TextBox;
 
+import com.vertispan.webdriver.gwt.gwtdriver.by.GwtBy;
 import com.vertispan.webdriver.gwt.gwtdriver.invoke.ClientMethodsFactory;
 import com.vertispan.webdriver.gwt.gwtdriver.invoke.ExportedMethods;
 import com.vertispan.webdriver.gwt.gwtdriver.models.Dialog.DialogFinder;
@@ -203,7 +204,6 @@ public class SimpleWidgetTest {
         rootPanel.getElement(), Label.class.getName());
     assertEquals("testing", new GwtLabel(driver, firstLabel).getText());
 
-
     // let's validate direct children fetch; only looking in panel2
     WidgetContainer panel2 = rootPanel.findWidget(By.cssSelector(".panel2"))
         .as(WidgetContainer.class);
@@ -212,5 +212,11 @@ public class SimpleWidgetTest {
     exportedMethods.instanceofwidget(panel2Children.get(0), Label.class.getName());
     exportedMethods.instanceofwidget(panel2Children.get(1), Button.class.getName());
     exportedMethods.instanceofwidget(panel2Children.get(2), FlowPanel.class.getName());
+
+    // similar test as above, but using the ByDescendantWidget
+    List<WebElement> elements = driver.findElements(GwtBy.descendantWidget(Label.class));
+    // all labels
+    assertEquals(5, elements.size());
+    System.out.println(elements.size());
   }
 }

--- a/src/test/java/com/vertispan/webdriver/gwt/gwtdriver/models/SimpleWidgetTest.java
+++ b/src/test/java/com/vertispan/webdriver/gwt/gwtdriver/models/SimpleWidgetTest.java
@@ -17,8 +17,15 @@
  */
 package com.vertispan.webdriver.gwt.gwtdriver.models;
 
-import com.google.gwt.user.client.ui.RootPanel;
+import static org.junit.jupiter.api.Assertions.*;
 
+import com.google.gwt.user.client.ui.Label;
+import com.google.gwt.user.client.ui.Panel;
+import com.google.gwt.user.client.ui.RootPanel;
+import com.google.gwt.user.client.ui.TextBox;
+
+import com.vertispan.webdriver.gwt.gwtdriver.invoke.ClientMethodsFactory;
+import com.vertispan.webdriver.gwt.gwtdriver.invoke.ExportedMethods;
 import com.vertispan.webdriver.gwt.gwtdriver.models.Dialog.DialogFinder;
 
 import org.eclipse.jetty.server.NetworkConnector;
@@ -30,6 +37,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.Point;
+import org.openqa.selenium.WebElement;
 import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.chrome.ChromeOptions;
 import org.openqa.selenium.interactions.Actions;
@@ -104,7 +112,7 @@ public class SimpleWidgetTest {
     //*FlowPanel
     //**TextBox
     //**Button
-    assert children.size() == 4 : children.size();
+    assert children.size() == 5 : children.size();
 
     //find Label by iterating through sub-widgets and as'ing
     GwtLabel label = children.get(0).as(GwtLabel.class);
@@ -148,5 +156,40 @@ public class SimpleWidgetTest {
 //			assert movedHeaderLoc.equals(children.get(3).getElement().getLocation());
 
     assert topDialog.getElement().getText().contains("fdsa");
+  }
+
+
+  @Test
+  void testFindDescedantWidgets() {
+    driver.get(url);
+
+    WidgetContainer rootPanel = new GwtRootPanel(driver);
+    assert rootPanel.as(GwtRootPanel.class) != null;
+
+    ExportedMethods exportedMethods = ClientMethodsFactory.create(ExportedMethods.class, driver);
+
+    // find all widgets under a context
+    List<WebElement> allWidgetElements = exportedMethods
+        .findDescendantWidgetElements(rootPanel.getElement());
+
+    // should be 6 (including root panel)
+    assertEquals(6, allWidgetElements.size());
+    exportedMethods.instanceofwidget(allWidgetElements.get(1), Label.class.getName());
+    exportedMethods.instanceofwidget(allWidgetElements.get(2), Panel.class.getName());
+    exportedMethods.instanceofwidget(allWidgetElements.get(3), TextBox.class.getName());
+    exportedMethods.instanceofwidget(allWidgetElements.get(4),
+        com.google.gwt.user.client.ui.Button.class.getName());
+    exportedMethods.instanceofwidget(allWidgetElements.get(5), Label.class.getName());
+
+    // find descendant of type
+    List<WebElement> buttons = exportedMethods.findDescendantWidgetElementsOfType(
+        rootPanel.getElement(),
+        com.google.gwt.user.client.ui.Button.class.getName());
+    assertEquals(1, buttons.size());
+
+    // find first widget type
+    WebElement firstLabel = exportedMethods.findFirstDescendantWidgetElementsOfType(
+        rootPanel.getElement(), Label.class.getName());
+    assertEquals("testing", new GwtLabel(driver, firstLabel).getText());
   }
 }

--- a/src/test/java/com/vertispan/webdriver/gwt/gwtdriver/models/client/SimpleWidgetsEP.java
+++ b/src/test/java/com/vertispan/webdriver/gwt/gwtdriver/models/client/SimpleWidgetsEP.java
@@ -51,6 +51,7 @@ public class SimpleWidgetsEP implements EntryPoint {
         box.show();
       }
     }));
+    panel.add(new Label("Another Label in the panel"));
   }
 
 }

--- a/src/test/java/com/vertispan/webdriver/gwt/gwtdriver/models/client/SimpleWidgetsEP.java
+++ b/src/test/java/com/vertispan/webdriver/gwt/gwtdriver/models/client/SimpleWidgetsEP.java
@@ -18,40 +18,42 @@
 package com.vertispan.webdriver.gwt.gwtdriver.models.client;
 
 import com.google.gwt.core.client.EntryPoint;
+import com.google.gwt.core.client.GWT;
 import com.google.gwt.event.dom.client.ClickEvent;
-import com.google.gwt.event.dom.client.ClickHandler;
-import com.google.gwt.user.client.ui.Button;
+import com.google.gwt.uibinder.client.UiBinder;
+import com.google.gwt.uibinder.client.UiField;
+import com.google.gwt.uibinder.client.UiHandler;
 import com.google.gwt.user.client.ui.DialogBox;
-import com.google.gwt.user.client.ui.FlowPanel;
 import com.google.gwt.user.client.ui.HTML;
 import com.google.gwt.user.client.ui.Label;
 import com.google.gwt.user.client.ui.RootPanel;
 import com.google.gwt.user.client.ui.TextBox;
+import com.google.gwt.user.client.ui.Widget;
 
 public class SimpleWidgetsEP implements EntryPoint {
 
-  @Override
-  public void onModuleLoad() {
-
-    RootPanel.get().add(new Label("testing"));
-
-    FlowPanel panel = new FlowPanel();
-    RootPanel.get().add(panel);
-
-    final TextBox textBox = new TextBox();
-    textBox.setValue("asdf");
-    panel.add(textBox);
-
-    panel.add(new Button("Open dialog", new ClickHandler() {
-      @Override
-      public void onClick(ClickEvent event) {
-        DialogBox box = new DialogBox();
-        box.setText("Heading Text For Dialog");
-        box.add(new HTML(textBox.getValue()));
-        box.show();
-      }
-    }));
-    panel.add(new Label("Another Label in the panel"));
+  interface MyUiBinder extends UiBinder<Widget, SimpleWidgetsEP> {
   }
 
+  private MyUiBinder uiBinder = GWT.create(MyUiBinder.class);
+
+  @UiField
+  TextBox textBox;
+
+  @Override
+  public void onModuleLoad() {
+    // outside of UiBinder
+    RootPanel.get().add(new Label("testing"));
+
+    // add UiBinder UI
+    RootPanel.get().add(uiBinder.createAndBindUi(this));
+  }
+
+  @UiHandler("openDialog")
+  void onOpenDialog(ClickEvent event) {
+    DialogBox box = new DialogBox();
+    box.setText("Heading Text For Dialog");
+    box.add(new HTML(textBox.getValue()));
+    box.show();
+  }
 }

--- a/src/test/java/com/vertispan/webdriver/gwt/gwtdriver/models/client/SimpleWidgetsEP.ui.xml
+++ b/src/test/java/com/vertispan/webdriver/gwt/gwtdriver/models/client/SimpleWidgetsEP.ui.xml
@@ -1,0 +1,76 @@
+<!--
+
+    Copyright 2013 Colin Alworth
+    Copyright 2012-2013 Sencha Labs
+    Copyright 2022 Vertispan LLC
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
+<ui:UiBinder
+  xmlns:ui="urn:ui:com.google.gwt.uibinder"
+  xmlns:g="urn:import:com.google.gwt.user.client.ui">
+  <ui:style>
+    /* ensure it doesn't get obfuscated */
+    @external panel1, panel2;
+
+    .panel1, .panel2 {
+    }
+
+    .container {
+      display: flex;
+      flex-direction: column;
+      gap: 20px;
+    }
+  </ui:style>
+
+  <g:HTMLPanel addStyleNames="{style.container}">
+
+    <g:FlowPanel ui:field="panel" addStyleNames="{style.panel1}">
+      <g:TextBox ui:field="textBox" value="asdf"/>
+      <g:Button ui:field="openDialog">Open dialog</g:Button>
+      <g:Label text="Another Label in the panel"/>
+    </g:FlowPanel>
+
+    <!-- make sure that the extra HTML doesn't cause any issues with finders -->
+    <div>
+      <table>
+        <thead>
+          <tr>
+            <th>Column 1</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              <g:Label text="This is label inside of table"/>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <g:FlowPanel addStyleNames="{style.panel2}">
+      <g:Label text="child1"/>
+      <g:Button text="child2"/>
+      <g:FlowPanel> <!-- child 3 -->
+        <g:Label text="Not a direct child" />
+        <g:TextBox value="This should also not be in direct children"/>
+      </g:FlowPanel>
+    </g:FlowPanel>
+
+
+  </g:HTMLPanel>
+
+</ui:UiBinder>

--- a/src/test/java/com/vertispan/webdriver/gwt/gwtdriver/models/client/SimpleWidgetsEP.ui.xml
+++ b/src/test/java/com/vertispan/webdriver/gwt/gwtdriver/models/client/SimpleWidgetsEP.ui.xml
@@ -1,7 +1,5 @@
 <!--
 
-    Copyright 2013 Colin Alworth
-    Copyright 2012-2013 Sencha Labs
     Copyright 2022 Vertispan LLC
 
     Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
Updated the unit test to utilize uibinder for easier test UI creation

Added 4 new exported methods:
- getChildren
  - returns direct children of provided elements widget
- findDescendantWidgetElementsOfType
  -  finds all descendant widget elements of provided element widget of a specified type
- findDescendantWidgetElements
  - finds all descendant widget elements
- findFirstDescendantWidgetElementsOfType
  - locates the first descendant widget element of a specific type


Added a new "By" for the descendants search

Added a base GwtBy class with some helpers.

Modified each By implementation that needs a WebDriver to extract from the SearchContext